### PR TITLE
fix: security alert CVE-2018-10237 (https://github.com/advisories/GHSA-mvr2-9pj6-7w5j

### DIFF
--- a/nifi-influx-database-processors/pom.xml
+++ b/nifi-influx-database-processors/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>29.0-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update `Guava` dependency to avoid security alert.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)