### PR TITLE
fix: disable bintray repository which is shutted down

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,17 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</pluginRepository>
+		<pluginRepository>
+			<id>maven2</id>
+			<name>maven2</name>
+			<url>https://repo1.maven.org/maven2/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
 
 	</pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,16 @@
 		<!-- skip until remove org.json from Java client -->
         <enforcer.skip>true</enforcer.skip>
 
+		<!--
+			TODO after update NiFi:
+				- remote nifi.groovy.version property
+				- remove bintray pluginRepository
+		 -->
         <nifi.version>1.13.2</nifi.version>
 
         <plugin.surefire.version>2.22.0</plugin.surefire.version>
         <plugin.jacoco.version>0.8.2</plugin.jacoco.version>
+		<nifi.groovy.version>2.5.6</nifi.groovy.version>
     </properties>
 
     <dependencyManagement>
@@ -399,5 +405,20 @@
         </repository>
 
     </repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>bintray</id>
+			<name>Groovy Bintray</name>
+			<url>https://dl.bintray.com/groovy/maven</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+
+	</pluginRepositories>
 
 </project>


### PR DESCRIPTION
Related to https://github.com/apache/nifi/commit/de3e1a0d0d6c85cb89ce66c08a476048f003c9d1

Fix building: 

```
INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.767 s
[INFO] Finished at: 2021-05-28T00:08:36Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (groovy-tests) on project nifi-influx-database-bundle: Execution groovy-tests of goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile failed: Plugin org.apache.maven.plugins:maven-compiler-plugin:3.8.1 or one of its dependencies could not be resolved: Failed to collect dependencies at org.apache.maven.plugins:maven-compiler-plugin:jar:3.8.1 -> org.codehaus.groovy:groovy-eclipse-batch:jar:2.5.4-01: Failed to read artifact descriptor for org.codehaus.groovy:groovy-eclipse-batch:jar:2.5.4-01: Could not transfer artifact org.codehaus.groovy:groovy-eclipse-batch:pom:2.5.4-01 from/to bintray (https://dl.bintray.com/groovy/maven): Authorization failed for https://dl.bintray.com/groovy/maven/org/codehaus/groovy/groovy-eclipse-batch/2.5.4-01/groovy-eclipse-batch-2.5.4-01.pom 403 Forbidden -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException

Exited with code exit status 1
```

https://app.circleci.com/jobs/github/influxdata/nifi-influxdb-bundle/183?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification


- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)