### PR TITLE
fix: link to CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -5,4 +5,4 @@ _Briefly describe your proposed changes:_
 - [ ] CHANGELOG.md updated
 - [ ] Rebased/mergeable
 - [ ] Tests pass
-- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
+- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)


### PR DESCRIPTION
## Proposed Changes

Fixed link to CLA.

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)