### PR TITLE
chore(ci): use new codecov uploader for reporting code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,16 @@ jobs:
           jdk-version: << parameters.jdk-version >>
       - storing-test-results
       - run:
-          name: "Collecting coverage reports"
-          command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+          name: Collecting coverage reports
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x ./codecov
+            ./codecov
 
   end-to-end:
     machine:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Others
 1. [#65](https://github.com/influxdata/nifi-influxdb-bundle/pull/65): Update to Apache NiFi 1.15.3
 
+### CI
+1. [#66](https://github.com/influxdata/nifi-influxdb-bundle/pull/66): Use new Codecov uploader for reporting code coverage
+
 ## v1.15.0 [2022-01-20]
 
 ### Others


### PR DESCRIPTION
_Briefly describe your proposed changes:_

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)