### PR TITLE
feat: add `Retry-After` header as FlowFile attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.16.0 [unreleased]
 
+### Features
+1. [#67](https://github.com/influxdata/nifi-influxdb-bundle/pull/67): Add `Retry-After` header value when a FlowFile is transferred to `Retry` output
+
 ### Others
 1. [#65](https://github.com/influxdata/nifi-influxdb-bundle/pull/65): Update to Apache NiFi 1.15.3
 

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabaseRecord_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabaseRecord_2.java
@@ -181,10 +181,10 @@ public class PutInfluxDatabaseRecord_2 extends AbstractInfluxDatabaseProcessor_2
             if (Arrays.asList(429, 503).contains(ie.status()) || ie.getCause() instanceof SocketTimeoutException) {
                 getLogger().error("Failed to insert into influxDB due {} to {} and retrying",
                         new Object[]{ie.status(), ie.getLocalizedMessage()}, ie);
-				String retryAfterHeader = getRetryAfterHeader(ie);
-				if (StringUtils.isNoneBlank(retryAfterHeader)) {
-					flowFile = session.putAttribute(flowFile, INFLUX_DB_RETRY_AFTER, retryAfterHeader);
-				}
+                String retryAfterHeader = getRetryAfterHeader(ie);
+                if (StringUtils.isNoneBlank(retryAfterHeader)) {
+                    flowFile = session.putAttribute(flowFile, INFLUX_DB_RETRY_AFTER, retryAfterHeader);
+                }
                 session.penalize(flowFile);
                 session.transfer(flowFile, REL_RETRY);
             } else {

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabaseRecord_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabaseRecord_2.java
@@ -52,6 +52,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.INFLUX_DB_ERROR_MESSAGE;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.INFLUX_DB_FAIL_TO_INSERT;
+import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.INFLUX_DB_RETRY_AFTER;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.MAX_RECORDS_SIZE;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.RECORD_READER_FACTORY;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.REL_FAILURE;
@@ -180,6 +181,10 @@ public class PutInfluxDatabaseRecord_2 extends AbstractInfluxDatabaseProcessor_2
             if (Arrays.asList(429, 503).contains(ie.status()) || ie.getCause() instanceof SocketTimeoutException) {
                 getLogger().error("Failed to insert into influxDB due {} to {} and retrying",
                         new Object[]{ie.status(), ie.getLocalizedMessage()}, ie);
+				String retryAfterHeader = getRetryAfterHeader(ie);
+				if (StringUtils.isNoneBlank(retryAfterHeader)) {
+					flowFile = session.putAttribute(flowFile, INFLUX_DB_RETRY_AFTER, retryAfterHeader);
+				}
                 session.penalize(flowFile);
                 session.transfer(flowFile, REL_RETRY);
             } else {

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabase_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabase_2.java
@@ -170,11 +170,11 @@ public class PutInfluxDatabase_2 extends AbstractInfluxDatabaseProcessor_2 {
             if (Arrays.asList(429, 503).contains(ie.status()) || ie.getCause() instanceof SocketTimeoutException) {
                 getLogger().error("Failed to insert into influxDB due {} to {} and retrying",
                         new Object[]{ie.status(), ie.getLocalizedMessage()}, ie);
-				String retryAfterHeader = getRetryAfterHeader(ie);
-				if (StringUtils.isNoneBlank(retryAfterHeader)) {
-					flowFile = session.putAttribute(flowFile, INFLUX_DB_RETRY_AFTER, retryAfterHeader);
-				}
-				session.transfer(flowFile, REL_RETRY);
+                String retryAfterHeader = getRetryAfterHeader(ie);
+                if (StringUtils.isNoneBlank(retryAfterHeader)) {
+                    flowFile = session.putAttribute(flowFile, INFLUX_DB_RETRY_AFTER, retryAfterHeader);
+                }
+                session.transfer(flowFile, REL_RETRY);
             } else {
                 getLogger().error(INFLUX_DB_FAIL_TO_INSERT, new Object[]{ie.getLocalizedMessage()}, ie);
                 session.transfer(flowFile, REL_FAILURE);

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabase_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabase_2.java
@@ -31,6 +31,7 @@ import com.influxdb.exceptions.InfluxException;
 import org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor_2;
 import org.influxdata.nifi.util.PropertyValueUtils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
@@ -54,6 +55,7 @@ import static org.influxdata.nifi.processors.PutInfluxDatabase.REL_SUCCESS;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.CHARSET;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.INFLUX_DB_ERROR_MESSAGE;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.INFLUX_DB_FAIL_TO_INSERT;
+import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.INFLUX_DB_RETRY_AFTER;
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.MAX_RECORDS_SIZE;
 
 /**
@@ -168,7 +170,11 @@ public class PutInfluxDatabase_2 extends AbstractInfluxDatabaseProcessor_2 {
             if (Arrays.asList(429, 503).contains(ie.status()) || ie.getCause() instanceof SocketTimeoutException) {
                 getLogger().error("Failed to insert into influxDB due {} to {} and retrying",
                         new Object[]{ie.status(), ie.getLocalizedMessage()}, ie);
-                session.transfer(flowFile, REL_RETRY);
+				String retryAfterHeader = getRetryAfterHeader(ie);
+				if (StringUtils.isNoneBlank(retryAfterHeader)) {
+					flowFile = session.putAttribute(flowFile, INFLUX_DB_RETRY_AFTER, retryAfterHeader);
+				}
+				session.transfer(flowFile, REL_RETRY);
             } else {
                 getLogger().error(INFLUX_DB_FAIL_TO_INSERT, new Object[]{ie.getLocalizedMessage()}, ie);
                 session.transfer(flowFile, REL_FAILURE);

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
@@ -129,6 +129,7 @@ public abstract class AbstractInfluxDatabaseProcessor extends AbstractProcessor 
 
 
     public static final String INFLUX_DB_ERROR_MESSAGE = "influxdb.error.message";
+    public static final String INFLUX_DB_RETRY_AFTER = "influxdb.retry-after";
     public static final String INFLUX_DB_ERROR_MESSAGE_LOG = "Failed procession flow file {} due to {}";
     public static final String INFLUX_DB_FAIL_TO_INSERT = "Failed to insert into influxDB due to {}";
     public static final String INFLUX_DB_FAIL_TO_QUERY = "Failed to execute Flux query due {} to {}";

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor_2.java
@@ -204,7 +204,9 @@ public abstract class AbstractInfluxDatabaseProcessor_2 extends AbstractProcesso
 	protected String getRetryAfterHeader(InfluxException ie) {
 		try
 		{
-			// this is temporally solution we have made "response" public
+            //
+			// Temporally solution before release https://github.com/influxdata/influxdb-client-java/pull/317
+            //
 			Field responseField = InfluxException.class.getDeclaredField("response");
 			responseField.setAccessible(true);
 			Response response = (Response) responseField.get(ie);

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor_2.java
@@ -16,13 +16,16 @@
  */
 package org.influxdata.nifi.processors.internal;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 import com.influxdb.LogLevel;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.exceptions.InfluxException;
 import org.influxdata.nifi.services.InfluxDatabaseService_2;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -36,6 +39,7 @@ import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.StandardValidators;
+import retrofit2.Response;
 
 import static org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor.MAX_RECORDS_SIZE;
 import static org.influxdata.nifi.util.PropertyValueUtils.getEnumValue;
@@ -196,7 +200,27 @@ public abstract class AbstractInfluxDatabaseProcessor_2 extends AbstractProcesso
         return influxDBClient.get();
     }
 
-    /**
+	@Nullable
+	protected String getRetryAfterHeader(InfluxException ie) {
+		try
+		{
+			// this is temporally solution we have made "response" public
+			Field responseField = InfluxException.class.getDeclaredField("response");
+			responseField.setAccessible(true);
+			Response response = (Response) responseField.get(ie);
+			if (response != null) {
+				return response.headers().get("Retry-After");
+			}
+		}
+		catch (Exception e)
+		{
+			return null;
+		}
+
+		return null;
+	}
+
+	/**
      * Configure LogLevel and GZIP.
      */
     private void configure(@NonNull final InfluxDBClient influxDBClient, @NonNull final ProcessContext context) {

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor_2.java
@@ -200,29 +200,26 @@ public abstract class AbstractInfluxDatabaseProcessor_2 extends AbstractProcesso
         return influxDBClient.get();
     }
 
-	@Nullable
-	protected String getRetryAfterHeader(InfluxException ie) {
-		try
-		{
+    @Nullable
+    protected String getRetryAfterHeader(InfluxException ie) {
+        try {
             //
-			// Temporally solution before release https://github.com/influxdata/influxdb-client-java/pull/317
+            // Temporally solution before release https://github.com/influxdata/influxdb-client-java/pull/317
             //
-			Field responseField = InfluxException.class.getDeclaredField("response");
-			responseField.setAccessible(true);
-			Response response = (Response) responseField.get(ie);
-			if (response != null) {
-				return response.headers().get("Retry-After");
-			}
-		}
-		catch (Exception e)
-		{
-			return null;
-		}
+            Field responseField = InfluxException.class.getDeclaredField("response");
+            responseField.setAccessible(true);
+            Response response = (Response) responseField.get(ie);
+            if (response != null) {
+                return response.headers().get("Retry-After");
+            }
+        } catch (Exception e) {
+            return null;
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	/**
+    /**
      * Configure LogLevel and GZIP.
      */
     private void configure(@NonNull final InfluxDBClient influxDBClient, @NonNull final ProcessContext context) {

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/Utils.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/Utils.java
@@ -42,7 +42,7 @@ class Utils {
 
         headers.forEach(builder::addHeader);
 
-        return Response.error(ResponseBody.create(MediaType.parse("application/json"), ""), builder.build());
+        return Response.error(ResponseBody.create("", MediaType.parse("application/json")), builder.build());
     }
 
 }

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/Utils.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/Utils.java
@@ -16,6 +16,10 @@
  */
 package org.influxdata.nifi.processors;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -24,16 +28,21 @@ import retrofit2.Response;
 
 class Utils {
 
-    static Response createErrorResponse(final int code) {
-        okhttp3.Response build = new okhttp3.Response.Builder() //
-                .code(code).addHeader("X-Influx-Error", "Simulate error: " + code)
+    static Response<Object> createErrorResponse(final int code) {
+        return createErrorResponse(code, new HashMap<>());
+    }
+
+    static Response<Object> createErrorResponse(final int code, @Nonnull final Map<String, String> headers) {
+        okhttp3.Response.Builder builder = new okhttp3.Response.Builder() //
+                .code(code)
+                .addHeader("X-Influx-Error", "Simulate error: " + code)
                 .message("Response.error()")
                 .protocol(Protocol.HTTP_1_1)
-                .request(new Request.Builder().url("http://localhost/").build())
-                .build();
+                .request(new Request.Builder().url("http://localhost/").build());
 
-        return Response
-                .error(ResponseBody.create(MediaType.parse("application/json"), ""), build);
+        headers.forEach(builder::addHeader);
+
+        return Response.error(ResponseBody.create(MediaType.parse("application/json"), ""), builder.build());
     }
 
 }


### PR DESCRIPTION
The processors put the `Retry-After` header value as a FlowFile Attribute (`influxdb.retry-after`) before sending the FlowFile to the “Retry” output.

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)