### PR TITLE
feat:  add possibility to customize the User-Agent HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.20.0 [unreleased]
 
+### Features
+1. [#74](https://github.com/influxdata/nifi-influxdb-bundle/pull/74): Add possibility to customize the `User-Agent` HTTP header
+
 ### Others
 1. [#73](https://github.com/influxdata/nifi-influxdb-bundle/pull/73): Update to Apache NiFi 1.16.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### Features
 1. [#74](https://github.com/influxdata/nifi-influxdb-bundle/pull/74): Add possibility to customize the `User-Agent` HTTP header
 
+### Dependencies
+1. [#74](https://github.com/influxdata/nifi-influxdb-bundle/pull/74): Update dependencies:
+   - `influxdb-client-java` to `6.3.0`
+   - `influxdb-java` to `2.22`
+
 ### Others
 1. [#73](https://github.com/influxdata/nifi-influxdb-bundle/pull/73): Update to Apache NiFi 1.16.3
 

--- a/nifi-influx-database-processors/pom.xml
+++ b/nifi-influx-database-processors/pom.xml
@@ -153,6 +153,12 @@
 			<artifactId>assertj-core</artifactId>
 			<version>3.11.1</version>
 		</dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/ExecuteInfluxDatabaseQuery.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/ExecuteInfluxDatabaseQuery.java
@@ -138,6 +138,7 @@ public class ExecuteInfluxDatabaseQuery extends AbstractInfluxDatabaseProcessor 
         tempDescriptors.add(USERNAME);
         tempDescriptors.add(PASSWORD);
         tempDescriptors.add(CHARSET);
+        tempDescriptors.add(INFLUX_DB_CLIENT_TYPE);
         propertyDescriptors = Collections.unmodifiableList(tempDescriptors);
     }
 

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabase.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/PutInfluxDatabase.java
@@ -120,6 +120,7 @@ public class PutInfluxDatabase extends AbstractInfluxDatabaseProcessor {
         tempDescriptors.add(RETENTION_POLICY);
         tempDescriptors.add(TIMESTAMP_PRECISION);
         tempDescriptors.add(MAX_RECORDS_SIZE);
+        tempDescriptors.add(INFLUX_DB_CLIENT_TYPE);
         propertyDescriptors = Collections.unmodifiableList(tempDescriptors);
     }
 

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
@@ -75,6 +75,16 @@ public abstract class AbstractInfluxDatabaseProcessor extends AbstractProcessor 
             .sensitive(false)
             .build();
 
+    public static final PropertyDescriptor INFLUX_DB_CLIENT_TYPE = new PropertyDescriptor.Builder()
+            .name("influxdb-client-type")
+            .displayName("InfluxDB Client type")
+            .description("Customize the User-Agent HTTP header. If the value is set to \"awesome-service\" "
+                    + "the User-Agent header will be: \"influxdb-client-awesome-service/6.2.0\".")
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .sensitive(false)
+            .build();
+
     public static final PropertyDescriptor DB_NAME = new PropertyDescriptor.Builder()
             .name("influxdb-dbname")
             .displayName("Database Name")
@@ -145,8 +155,9 @@ public abstract class AbstractInfluxDatabaseProcessor extends AbstractProcessor 
             String password = context.getProperty(PASSWORD).evaluateAttributeExpressions().getValue();
             long connectionTimeout = context.getProperty(INFLUX_DB_CONNECTION_TIMEOUT).asTimePeriod(TimeUnit.SECONDS);
             String influxDbUrl = context.getProperty(INFLUX_DB_URL).evaluateAttributeExpressions().getValue();
+            String clientType = context.getProperty(INFLUX_DB_CLIENT_TYPE).getValue();
             try {
-                influxDB.set(makeConnection(username, password, influxDbUrl, connectionTimeout));
+                influxDB.set(makeConnection(username, password, influxDbUrl, connectionTimeout, clientType));
             } catch(Exception e) {
                 getLogger().error("Error while getting connection {}", new Object[] { e.getLocalizedMessage() },e);
                 throw new RuntimeException("Error while getting connection " + e.getLocalizedMessage(),e);
@@ -161,8 +172,8 @@ public abstract class AbstractInfluxDatabaseProcessor extends AbstractProcessor 
     public void onScheduled(final ProcessContext context) {
     }
 
-    protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
-        return InfluxDBUtils.makeConnectionV1(influxDbUrl, username, password, connectionTimeout, null);
+    protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
+        return InfluxDBUtils.makeConnectionV1(influxDbUrl, username, password, connectionTimeout, null, clientType);
     }
 
     @OnStopped

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
@@ -19,9 +19,9 @@ package org.influxdata.nifi.processors.internal;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import okhttp3.OkHttpClient;
-import okhttp3.OkHttpClient.Builder;
-import org.apache.commons.lang3.StringUtils;
+import org.influxdata.nifi.util.InfluxDBUtils;
+import org.influxdb.InfluxDB;
+
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -31,8 +31,6 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.serialization.RecordReaderFactory;
-import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDBFactory;
 
 /**
  * Abstract base class for InfluxDB processors
@@ -164,12 +162,7 @@ public abstract class AbstractInfluxDatabaseProcessor extends AbstractProcessor 
     }
 
     protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
-        Builder builder = new OkHttpClient.Builder().connectTimeout(connectionTimeout, TimeUnit.SECONDS);
-        if ( StringUtils.isBlank(username) || StringUtils.isBlank(password) ) {
-            return InfluxDBFactory.connect(influxDbUrl, builder);
-        } else {
-            return InfluxDBFactory.connect(influxDbUrl, username, password, builder);
-        }
+        return InfluxDBUtils.makeConnection(username, password, influxDbUrl, connectionTimeout, null);
     }
 
     @OnStopped

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractInfluxDatabaseProcessor.java
@@ -162,7 +162,7 @@ public abstract class AbstractInfluxDatabaseProcessor extends AbstractProcessor 
     }
 
     protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
-        return InfluxDBUtils.makeConnection(username, password, influxDbUrl, connectionTimeout, null);
+        return InfluxDBUtils.makeConnectionV1(influxDbUrl, username, password, connectionTimeout, null);
     }
 
     @OnStopped

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB.java
@@ -19,10 +19,11 @@ package org.influxdata.nifi.processors;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.influxdata.nifi.util.InfluxDBUtils;
+
 import com.google.gson.reflect.TypeToken;
 import org.apache.nifi.util.TestRunner;
 import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 import org.junit.After;
@@ -41,8 +42,8 @@ public abstract class AbstractITInfluxDB {
 
     protected Type QueryResultListType = new TypeToken<List<QueryResult>>(){}.getType();
 
-    protected void initInfluxDB() throws InterruptedException, Exception {
-        influxDB = InfluxDBFactory.connect(dbUrl,user,password);
+    protected void initInfluxDB() throws Exception {
+        influxDB = InfluxDBUtils.makeConnection(user, password, dbUrl, 10, null);
         influxDB.query(new Query("CREATE database " + dbName, dbName));
         int max = 10;
         while (!databaseExists(dbName) && (max-- < 0)) {

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB.java
@@ -43,7 +43,7 @@ public abstract class AbstractITInfluxDB {
     protected Type QueryResultListType = new TypeToken<List<QueryResult>>(){}.getType();
 
     protected void initInfluxDB() throws Exception {
-        influxDB = InfluxDBUtils.makeConnectionV1(dbUrl, user, password, 10, null);
+        influxDB = InfluxDBUtils.makeConnectionV1(dbUrl, user, password, 10, null, null);
         influxDB.query(new Query("CREATE database " + dbName, dbName));
         int max = 10;
         while (!databaseExists(dbName) && (max-- < 0)) {

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB.java
@@ -20,12 +20,12 @@ import java.lang.reflect.Type;
 import java.util.List;
 
 import org.influxdata.nifi.util.InfluxDBUtils;
-
-import com.google.gson.reflect.TypeToken;
-import org.apache.nifi.util.TestRunner;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
+
+import com.google.gson.reflect.TypeToken;
+import org.apache.nifi.util.TestRunner;
 import org.junit.After;
 
 /**
@@ -43,7 +43,7 @@ public abstract class AbstractITInfluxDB {
     protected Type QueryResultListType = new TypeToken<List<QueryResult>>(){}.getType();
 
     protected void initInfluxDB() throws Exception {
-        influxDB = InfluxDBUtils.makeConnection(user, password, dbUrl, 10, null);
+        influxDB = InfluxDBUtils.makeConnectionV1(dbUrl, user, password, 10, null);
         influxDB.query(new Query("CREATE database " + dbName, dbName));
         int max = 10;
         while (!databaseExists(dbName) && (max-- < 0)) {

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB_2.java
@@ -47,7 +47,7 @@ abstract class AbstractITInfluxDB_2 {
 
     protected void init() {
 
-        influxDBClient = InfluxDBUtils.makeConnectionV2(INFLUX_DB_2, "my-token", 10, null);
+        influxDBClient = InfluxDBUtils.makeConnectionV2(INFLUX_DB_2, "my-token", 10, null, null);
 
         organization = influxDBClient.getOrganizationsApi().findOrganizations().stream()
                 .filter(it -> it.getName().equals("my-org"))

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB_2.java
@@ -27,6 +27,7 @@ import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.domain.Permission;
 import com.influxdb.client.domain.PermissionResource;
+
 import org.apache.nifi.util.TestRunner;
 import org.junit.After;
 
@@ -60,7 +61,7 @@ abstract class AbstractITInfluxDB_2 {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         //
         // Add Permissions to read and write to the Bucket

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/AbstractITInfluxDB_2.java
@@ -27,6 +27,7 @@ import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.domain.Permission;
 import com.influxdb.client.domain.PermissionResource;
+import org.influxdata.nifi.util.InfluxDBUtils;
 
 import org.apache.nifi.util.TestRunner;
 import org.junit.After;
@@ -44,9 +45,9 @@ abstract class AbstractITInfluxDB_2 {
     protected InfluxDBClient influxDBClient;
     protected Organization organization;
 
-    protected void init() throws Exception {
+    protected void init() {
 
-        influxDBClient = InfluxDBClientFactory.create(INFLUX_DB_2, "my-token".toCharArray());
+        influxDBClient = InfluxDBUtils.makeConnectionV2(INFLUX_DB_2, "my-token", 10, null);
 
         organization = influxDBClient.getOrganizationsApi().findOrganizations().stream()
                 .filter(it -> it.getName().equals("my-org"))

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/ITPutInfluxDatabase_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/ITPutInfluxDatabase_2.java
@@ -92,7 +92,7 @@ public class ITPutInfluxDatabase_2 extends AbstractITInfluxDB_2 {
 
         assertEquals(1, flowFiles.size());
 		Assertions.assertThat(flowFiles.get(0).getAttribute(AbstractInfluxDatabaseProcessor.INFLUX_DB_ERROR_MESSAGE))
-				.isEqualTo("unable to parse 'water,country=US,city=newark': missing fields");
+				.isEqualTo("HTTP status code: 400; Message: unable to parse 'water,country=US,city=newark': missing fields");
     }
 
     @Test

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestExecutetInfluxDBQuery.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestExecutetInfluxDBQuery.java
@@ -45,7 +45,7 @@ public class TestExecutetInfluxDBQuery {
     public void setUp() throws Exception {
         mockExecuteInfluxDBQuery = new ExecuteInfluxDatabaseQuery() {
             @Override
-            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
+            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
                 return null;
             }
 
@@ -78,7 +78,7 @@ public class TestExecutetInfluxDBQuery {
     public void testQueryThrowsRuntimeException() {
         mockExecuteInfluxDBQuery = new ExecuteInfluxDatabaseQuery() {
             @Override
-            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
+            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
                 return null;
             }
 
@@ -110,7 +110,7 @@ public class TestExecutetInfluxDBQuery {
     public void testQueryThrowsRuntimeExceptionWithSocketTimeoutException() {
         mockExecuteInfluxDBQuery = new ExecuteInfluxDatabaseQuery() {
             @Override
-            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
+            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
                 return null;
             }
 
@@ -142,7 +142,7 @@ public class TestExecutetInfluxDBQuery {
     public void testMakingQueryThrowsIOException() throws Throwable {
         mockExecuteInfluxDBQuery = new ExecuteInfluxDatabaseQuery() {
             @Override
-            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
+            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
                 return null;
             }
 
@@ -174,7 +174,7 @@ public class TestExecutetInfluxDBQuery {
     public void testMakeConnectionThrowsRuntimeException() {
         mockExecuteInfluxDBQuery = new ExecuteInfluxDatabaseQuery() {
             @Override
-            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
+            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
                 throw new RuntimeException("testException");
             }
 

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestGetInfluxDatabaseErrorHandling_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestGetInfluxDatabaseErrorHandling_2.java
@@ -26,6 +26,8 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;
 import org.influxdata.nifi.processors.internal.AbstractGetInfluxDatabase_2;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -121,7 +123,7 @@ public class TestGetInfluxDatabaseErrorHandling_2 extends AbstractTestGetInfluxD
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(relationship);
         Assert.assertEquals(1, flowFiles.size());
 
-        Assert.assertEquals(message, flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE));
+        Assertions.assertThat(flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE)).endsWith(message);
 
         List<LogMessage> errors = logger.getErrorMessages();
 

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestGetInfluxDatabaseRecordErrorHandling_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestGetInfluxDatabaseRecordErrorHandling_2.java
@@ -26,6 +26,8 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;
 import org.influxdata.nifi.processors.internal.AbstractGetInfluxDatabase_2;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -121,7 +123,7 @@ public class TestGetInfluxDatabaseRecordErrorHandling_2  extends AbstractTestGet
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(relationship);
         Assert.assertEquals(1, flowFiles.size());
 
-        Assert.assertEquals(message, flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE));
+        Assertions.assertThat(flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE)).endsWith(message);
 
         List<LogMessage> errors = logger.getErrorMessages();
 

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabase.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabase.java
@@ -44,7 +44,7 @@ public class TestPutInfluxDatabase {
         precision = null;
         mockPutInfluxDatabase = new PutInfluxDatabase() {
             @Override
-            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout) {
+            protected InfluxDB makeConnection(String username, String password, String influxDbUrl, long connectionTimeout, final String clientType) {
                 return null;
             }
 

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabaseRecordErrorHandling_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabaseRecordErrorHandling_2.java
@@ -33,6 +33,8 @@ import org.apache.nifi.util.MockFlowFile;
 import org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor;
 import org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor_2;
 import org.influxdata.nifi.util.InfluxDBUtils;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -252,7 +254,8 @@ public class TestPutInfluxDatabaseRecordErrorHandling_2 extends AbstractTestPutI
         Assert.assertEquals(1, errors.size());
 
         Assert.assertTrue(errors.get(0).getMsg().contains("Failed to insert into influxDB due "));
-		Assert.assertEquals("com.influxdb.exceptions.InfluxException: Simulate error: 503", errors.get(0).getArgs()[3]);
+        Assertions.assertThat(errors.get(0).getArgs()[3].toString()).startsWith("com.influxdb.exceptions.InfluxException");
+        Assertions.assertThat(errors.get(0).getArgs()[3].toString()).endsWith("Simulate error: 503");
     }
 
     private void errorToRetryRelationship(@NonNull final InfluxException exception,
@@ -288,7 +291,7 @@ public class TestPutInfluxDatabaseRecordErrorHandling_2 extends AbstractTestPutI
         runner.assertAllFlowFilesTransferred(relationship, 1);
 
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(relationship).get(0);
-        Assert.assertEquals(exceptionMessage, flowFile.getAttribute(INFLUX_DB_ERROR_MESSAGE));
+        Assertions.assertThat(flowFile.getAttribute(INFLUX_DB_ERROR_MESSAGE)).endsWith(exceptionMessage);
 
         // Is Penalized
         Assert.assertEquals(isPenalized, runner.getPenalizedFlowFiles().contains(flowFile));

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabase_2.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabase_2.java
@@ -35,6 +35,7 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -236,7 +237,7 @@ public class TestPutInfluxDatabase_2 {
 
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(REL_RETRY);
 
-        assertEquals("Simulate error: 503", flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE));
+        Assertions.assertThat(flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE)).endsWith("Simulate error: 503");
     }
 
     @Test
@@ -253,7 +254,7 @@ public class TestPutInfluxDatabase_2 {
 
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(REL_RETRY);
 
-        assertEquals("Simulate error: 429", flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE));
+        Assertions.assertThat(flowFiles.get(0).getAttribute(INFLUX_DB_ERROR_MESSAGE)).endsWith("Simulate error: 429");
     }
 
     @Test

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestUserAgent.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestUserAgent.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.influxdata.nifi.processors;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.influxdata.nifi.processors.internal.AbstractInfluxDatabaseProcessor;
+import org.influxdata.nifi.services.InfluxDatabaseService;
+import org.influxdata.nifi.services.StandardInfluxDatabaseService;
+import org.influxdata.nifi.services.StandardInfluxDatabaseService_2;
+import org.influxdata.nifi.util.InfluxDBUtils;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.MockRecordParser;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.MockProcessContext;
+import org.apache.nifi.util.MockProcessorInitializationContext;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestUserAgent {
+
+    private MockWebServer server;
+    private String baseURL;
+
+    @Before
+    public void setUp() {
+        server = new MockWebServer();
+        try {
+            server.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        baseURL = server.url("/").url().toString();
+    }
+
+    @After
+    public void after() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    public void testPutInfluxDatabase() throws InterruptedException {
+
+        server.enqueue(new MockResponse());
+        server.enqueue(new MockResponse());
+
+        TestRunner runner = TestRunners.newTestRunner(PutInfluxDatabase.class);
+        runner.setProperty(ExecuteInfluxDatabaseQuery.DB_NAME, "my-db");
+        runner.setProperty(ExecuteInfluxDatabaseQuery.USERNAME, "my-user");
+        runner.setProperty(ExecuteInfluxDatabaseQuery.PASSWORD, "my-password");
+        runner.setProperty(ExecuteInfluxDatabaseQuery.INFLUX_DB_URL, baseURL);
+        runner.setProperty(ExecuteInfluxDatabaseQuery.CHARSET, "UTF-8");
+        runner.assertValid();
+
+        String message = "water,country=US,city=newark rain=1,humidity=0.6 1";
+        byte[] bytes = message.getBytes();
+        runner.enqueue(bytes);
+        runner.run(1, true, true);
+        runner.assertAllFlowFilesTransferred(PutInfluxDatabase.REL_SUCCESS, 1);
+
+        Assert.assertEquals(1, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-java/");
+
+        runner.setProperty(ExecuteInfluxDatabaseQuery.INFLUX_DB_CLIENT_TYPE, "my-nifi");
+        runner.assertValid();
+
+        runner.enqueue(bytes);
+        runner.run(1, true, true);
+        runner.assertAllFlowFilesTransferred(PutInfluxDatabase.REL_SUCCESS, 2);
+
+        Assert.assertEquals(2, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-my-nifi/");
+    }
+
+    @Test
+    public void testExecuteInfluxDatabaseQuery() throws InterruptedException {
+        server.enqueue(new MockResponse().setBody("{}"));
+        server.enqueue(new MockResponse().setBody("{}"));
+
+        TestRunner runner = TestRunners.newTestRunner(ExecuteInfluxDatabaseQuery.class);
+        runner.setProperty(ExecuteInfluxDatabaseQuery.DB_NAME, "my-db");
+        runner.setProperty(ExecuteInfluxDatabaseQuery.USERNAME, "my-user");
+        runner.setProperty(ExecuteInfluxDatabaseQuery.PASSWORD, "my-password");
+        runner.setProperty(ExecuteInfluxDatabaseQuery.INFLUX_DB_URL, baseURL);
+        runner.setProperty(ExecuteInfluxDatabaseQuery.CHARSET, "UTF-8");
+        runner.assertValid();
+
+        runner.setProperty(ExecuteInfluxDatabaseQuery.INFLUX_DB_QUERY, "select * from water");
+
+        runner.setIncomingConnection(false);
+        runner.run(1, true, true);
+        runner.assertAllFlowFilesTransferred(ExecuteInfluxDatabaseQuery.REL_SUCCESS, 1);
+
+        Assert.assertEquals(1, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-java/");
+
+        runner.setProperty(ExecuteInfluxDatabaseQuery.INFLUX_DB_CLIENT_TYPE, "my-nifi");
+        runner.assertValid();
+
+        runner.run(1, true, true);
+        runner.assertAllFlowFilesTransferred(ExecuteInfluxDatabaseQuery.REL_SUCCESS, 2);
+
+        Assert.assertEquals(2, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-my-nifi/");
+    }
+
+    @Test
+    public void testPutInfluxDatabaseRecord() throws InterruptedException, InitializationException {
+        server.enqueue(new MockResponse().setBody("{}"));
+        server.enqueue(new MockResponse().setBody("{}"));
+
+        PutInfluxDatabaseRecord processor = new PutInfluxDatabaseRecord();
+
+        TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setProperty(PutInfluxDatabaseRecord.DB_NAME, "my-db");
+        runner.setProperty(InfluxDBUtils.MEASUREMENT, "testRecordMeasurement");
+        runner.setProperty(PutInfluxDatabaseRecord.RECORD_READER_FACTORY, "recordReader");
+        runner.setProperty(PutInfluxDatabaseRecord.INFLUX_DB_SERVICE, "influxdb-service");
+
+        MockRecordParser recordReader = new MockRecordParser();
+        runner.addControllerService("recordReader", recordReader);
+        runner.enableControllerService(recordReader);
+
+        InfluxDatabaseService influxDatabaseService = new StandardInfluxDatabaseService();
+        runner.addControllerService("influxdb-service", influxDatabaseService);
+        runner.setProperty(influxDatabaseService, InfluxDatabaseService.INFLUX_DB_URL, baseURL);
+        runner.enableControllerService(influxDatabaseService);
+
+        MockProcessContext context = new MockProcessContext(processor);
+        MockProcessorInitializationContext initContext = new MockProcessorInitializationContext(processor, context);
+        processor.initialize(initContext);
+
+        runner.setProperty(InfluxDBUtils.TAGS, "lang");
+        runner.setProperty(InfluxDBUtils.TIMESTAMP_FIELD, "timestamp");
+        runner.setProperty(InfluxDBUtils.FIELDS, "retweet_count");
+
+        recordReader.addSchemaField("lang", RecordFieldType.STRING);
+        recordReader.addSchemaField("retweet_count", RecordFieldType.INT);
+        recordReader.addSchemaField("timestamp", RecordFieldType.LONG);
+
+        recordReader.addRecord("en", 10, new Date());
+
+        runner.enqueue("");
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PutInfluxDatabaseRecord.REL_SUCCESS, 1);
+
+        Assert.assertEquals(1, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-java/");
+
+        runner.disableControllerService(influxDatabaseService);
+        runner.setProperty(influxDatabaseService, InfluxDatabaseService.INFLUX_DB_CLIENT_TYPE, "my-nifi");
+        runner.enableControllerService(influxDatabaseService);
+
+        recordReader.addRecord("cs", 25, new Date());
+
+        runner.enqueue("");
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PutInfluxDatabaseRecord.REL_SUCCESS, 2);
+
+        Assert.assertEquals(2, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-my-nifi/");
+    }
+
+    @Test
+    public void testPutInfluxDatabase2() throws InterruptedException, InitializationException {
+        server.enqueue(new MockResponse().setBody("{}"));
+        server.enqueue(new MockResponse().setBody("{}"));
+
+        PutInfluxDatabase_2 processor = new PutInfluxDatabase_2();
+
+        TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(PutInfluxDatabase_2.INFLUX_DB_SERVICE, "influxdb-service");
+        runner.setProperty(PutInfluxDatabase_2.BUCKET, "my-bucket");
+        runner.setProperty(PutInfluxDatabase_2.ORG, "my-org");
+
+        StandardInfluxDatabaseService_2 influxDatabaseService = new StandardInfluxDatabaseService_2();
+        runner.addControllerService("influxdb-service", influxDatabaseService);
+        runner.setProperty(influxDatabaseService, StandardInfluxDatabaseService_2.INFLUX_DB_URL, baseURL);
+        runner.setProperty(influxDatabaseService, StandardInfluxDatabaseService_2.INFLUX_DB_ACCESS_TOKEN, "my-token");
+        runner.enableControllerService(influxDatabaseService);
+
+        runner.enqueue("water,country=US,city=newark humidity=0.6 1".getBytes());
+        runner.run(1,true,true);
+        runner.assertAllFlowFilesTransferred(AbstractInfluxDatabaseProcessor.REL_SUCCESS, 1);
+
+        Assert.assertEquals(1, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-java/");
+
+        runner.disableControllerService(influxDatabaseService);
+        runner.setProperty(influxDatabaseService, StandardInfluxDatabaseService_2.INFLUX_DB_CLIENT_TYPE, "my-nifi");
+        runner.enableControllerService(influxDatabaseService);
+
+        runner.enqueue("water,country=US,city=newark humidity=0.6 1".getBytes());
+        runner.run(1,true,true);
+        runner.assertAllFlowFilesTransferred(AbstractInfluxDatabaseProcessor.REL_SUCCESS, 2);
+
+        Assert.assertEquals(2, server.getRequestCount());
+        Assertions.assertThat(server.takeRequest().getHeaders().get("User-Agent")).startsWith("influxdb-client-my-nifi/");
+    }
+}

--- a/nifi-influx-database-services-api/src/main/java/org/influxdata/nifi/services/InfluxDatabaseService.java
+++ b/nifi-influx-database-services-api/src/main/java/org/influxdata/nifi/services/InfluxDatabaseService.java
@@ -94,6 +94,16 @@ public interface InfluxDatabaseService extends ControllerService {
             .sensitive(true)
             .build();
 
+    PropertyDescriptor INFLUX_DB_CLIENT_TYPE = new PropertyDescriptor.Builder()
+            .name("influxdb-client-type")
+            .displayName("InfluxDB Client type")
+            .description("Customize the User-Agent HTTP header. If the value is set to \"awesome-service\" "
+                    + "the User-Agent header will be: \"influxdb-client-awesome-service/6.2.0\".")
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .sensitive(false)
+            .build();
+
     /**
      * Create a connection to a InfluxDB.
      *

--- a/nifi-influx-database-services-api/src/main/java/org/influxdata/nifi/services/InfluxDatabaseService_2.java
+++ b/nifi-influx-database-services-api/src/main/java/org/influxdata/nifi/services/InfluxDatabaseService_2.java
@@ -84,6 +84,16 @@ public interface InfluxDatabaseService_2 extends ControllerService {
             .sensitive(true)
             .build();
 
+    PropertyDescriptor INFLUX_DB_CLIENT_TYPE = new PropertyDescriptor.Builder()
+            .name("influxdb-client-type")
+            .displayName("InfluxDB Client type")
+            .description("Customize the User-Agent HTTP header. If the value is set to \"awesome-service\" "
+                    + "the User-Agent header will be: \"influxdb-client-awesome-service/6.2.0\".")
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .sensitive(false)
+            .build();
+
     /**
      * Create a connection to a InfluxDB 2.0.
      *

--- a/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService.java
+++ b/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService.java
@@ -112,7 +112,7 @@ public class StandardInfluxDatabaseService extends AbstractInfluxDatabaseService
                                final String influxDbUrl,
                                final long connectionTimeout) throws IOException {
 
-        return InfluxDBUtils.makeConnection(username, password, influxDbUrl, connectionTimeout, builder -> {
+        return InfluxDBUtils.makeConnectionV1(influxDbUrl, username, password, connectionTimeout, builder -> {
             if (sslService != null) {
                 configureSSL(builder, clientAuth, sslService);
             }

--- a/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService.java
+++ b/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService.java
@@ -52,6 +52,7 @@ public class StandardInfluxDatabaseService extends AbstractInfluxDatabaseService
         propertyDescriptors.add(INFLUX_DB_CONNECTION_TIMEOUT);
         propertyDescriptors.add(USERNAME);
         propertyDescriptors.add(PASSWORD);
+        propertyDescriptors.add(INFLUX_DB_CLIENT_TYPE);
 
         PROPERTY_DESCRIPTORS = Collections.unmodifiableList(propertyDescriptors);
     }
@@ -79,9 +80,11 @@ public class StandardInfluxDatabaseService extends AbstractInfluxDatabaseService
         // Credentials
         String username = context.getProperty(USERNAME).evaluateAttributeExpressions().getValue();
         String password = context.getProperty(PASSWORD).evaluateAttributeExpressions().getValue();
+        
+        String clientType = context.getProperty(INFLUX_DB_CLIENT_TYPE).getValue();
 
         try {
-            InfluxDB influxDB = connect(username, password, sslService, clientAuth, influxDbUrl, connectionTimeout);
+            InfluxDB influxDB = connect(username, password, sslService, clientAuth, influxDbUrl, connectionTimeout, clientType);
 
             getLogger().info("InfluxDB connection created for host {}", new Object[]{influxDbUrl});
 
@@ -110,13 +113,14 @@ public class StandardInfluxDatabaseService extends AbstractInfluxDatabaseService
                                final SSLContextService sslService,
                                final ClientAuth clientAuth,
                                final String influxDbUrl,
-                               final long connectionTimeout) throws IOException {
+                               final long connectionTimeout,
+                               final String clientType) throws IOException {
 
         return InfluxDBUtils.makeConnectionV1(influxDbUrl, username, password, connectionTimeout, builder -> {
             if (sslService != null) {
                 configureSSL(builder, clientAuth, sslService);
             }
-        });
+        }, clientType);
     }
 }
 

--- a/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService.java
+++ b/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService.java
@@ -23,17 +23,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.influxdata.nifi.util.InfluxDBUtils;
+import org.influxdb.InfluxDB;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
-import okhttp3.OkHttpClient;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
-import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDBFactory;
 
 import static org.influxdata.nifi.util.PropertyValueUtils.getEnumValue;
 
@@ -113,17 +112,11 @@ public class StandardInfluxDatabaseService extends AbstractInfluxDatabaseService
                                final String influxDbUrl,
                                final long connectionTimeout) throws IOException {
 
-
-        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(connectionTimeout, TimeUnit.SECONDS);
-        if (sslService != null) {
-            configureSSL(builder, clientAuth, sslService);
-        }
-
-        if (StringUtils.isBlank(username) || StringUtils.isBlank(password)) {
-            return InfluxDBFactory.connect(influxDbUrl, builder);
-        } else {
-            return InfluxDBFactory.connect(influxDbUrl, username, password, builder);
-        }
+        return InfluxDBUtils.makeConnection(username, password, influxDbUrl, connectionTimeout, builder -> {
+            if (sslService != null) {
+                configureSSL(builder, clientAuth, sslService);
+            }
+        });
     }
 }
 

--- a/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService_2.java
+++ b/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService_2.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.InfluxDBClientFactory;
+import org.influxdata.nifi.util.InfluxDBUtils;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
-import okhttp3.OkHttpClient;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -108,14 +108,11 @@ public class StandardInfluxDatabaseService_2 extends AbstractInfluxDatabaseServi
                                      final String influxDbUrl,
                                      final long connectionTimeout) throws IOException {
 
-
-        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(connectionTimeout, TimeUnit.SECONDS);
-        if (sslService != null) {
-            configureSSL(builder, clientAuth, sslService);
-        }
-
-        return InfluxDBClientFactory.create(influxDbUrl, token.toCharArray());
+        return InfluxDBUtils.makeConnectionV2(influxDbUrl, token, connectionTimeout, builder -> {
+            if (sslService != null) {
+                configureSSL(builder, clientAuth, sslService);
+            }
+        });
     }
-
 }
 

--- a/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService_2.java
+++ b/nifi-influx-database-services/src/main/java/org/influxdata/nifi/services/StandardInfluxDatabaseService_2.java
@@ -50,6 +50,7 @@ public class StandardInfluxDatabaseService_2 extends AbstractInfluxDatabaseServi
         propertyDescriptors.add(INFLUX_DB_URL);
         propertyDescriptors.add(INFLUX_DB_CONNECTION_TIMEOUT);
         propertyDescriptors.add(INFLUX_DB_ACCESS_TOKEN);
+        propertyDescriptors.add(INFLUX_DB_CLIENT_TYPE);
 
         PROPERTY_DESCRIPTORS = Collections.unmodifiableList(propertyDescriptors);
     }
@@ -77,8 +78,10 @@ public class StandardInfluxDatabaseService_2 extends AbstractInfluxDatabaseServi
         // Credentials
         String token = context.getProperty(INFLUX_DB_ACCESS_TOKEN).evaluateAttributeExpressions().getValue();
 
+        String clientType = context.getProperty(INFLUX_DB_CLIENT_TYPE).getValue();
+
         try {
-            InfluxDBClient client = connect(token, sslService, clientAuth, influxDbUrl, connectionTimeout);
+            InfluxDBClient client = connect(token, sslService, clientAuth, influxDbUrl, connectionTimeout, clientType);
 
             getLogger().info("InfluxDB 2.0 connection created for host {}", new Object[]{influxDbUrl});
 
@@ -106,13 +109,14 @@ public class StandardInfluxDatabaseService_2 extends AbstractInfluxDatabaseServi
                                      final SSLContextService sslService,
                                      final ClientAuth clientAuth,
                                      final String influxDbUrl,
-                                     final long connectionTimeout) throws IOException {
+                                     final long connectionTimeout,
+                                     final String clientType) throws IOException {
 
         return InfluxDBUtils.makeConnectionV2(influxDbUrl, token, connectionTimeout, builder -> {
             if (sslService != null) {
                 configureSSL(builder, clientAuth, sslService);
             }
-        });
+        }, clientType);
     }
 }
 

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService.java
@@ -59,7 +59,8 @@ public abstract class AbstractTestStandardInfluxDatabaseService {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any(),
-                        Mockito.anyLong());
+                        Mockito.anyLong(),
+                        null);
 
         testRunner = TestRunners.newTestRunner(ServiceProcessor.class);
         testRunner.addControllerService("influxdb-service", service);

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService.java
@@ -60,7 +60,7 @@ public abstract class AbstractTestStandardInfluxDatabaseService {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.anyLong(),
-                        null);
+                        Mockito.any());
 
         testRunner = TestRunners.newTestRunner(ServiceProcessor.class);
         testRunner.addControllerService("influxdb-service", service);

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService_2.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService_2.java
@@ -55,7 +55,8 @@ public abstract class AbstractTestStandardInfluxDatabaseService_2 {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any(),
-                        Mockito.anyLong());
+                        Mockito.anyLong(),
+                        null);
 
         testRunner = TestRunners.newTestRunner(ServiceProcessor.class);
         testRunner.addControllerService("influxdb-service", service);

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService_2.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/AbstractTestStandardInfluxDatabaseService_2.java
@@ -56,7 +56,7 @@ public abstract class AbstractTestStandardInfluxDatabaseService_2 {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.anyLong(),
-                        null);
+                        Mockito.any());
 
         testRunner = TestRunners.newTestRunner(ServiceProcessor.class);
         testRunner.addControllerService("influxdb-service", service);

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings.java
@@ -58,7 +58,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(ClientAuth.NONE),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8886"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -161,7 +161,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(6000L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -221,7 +221,7 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings.java
@@ -57,7 +57,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -92,7 +93,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(sslContextService),
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -110,7 +112,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(null),
                 Mockito.eq(ClientAuth.NONE),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -128,7 +131,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8886"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -156,7 +160,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(6000L));
+                Mockito.eq(6000L),
+                null);
     }
 
     @Test
@@ -186,7 +191,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -214,7 +220,8 @@ public class TestStandardInfluxDatabaseServiceSettings extends AbstractTestStand
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings_2.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings_2.java
@@ -55,7 +55,8 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -78,7 +79,8 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(sslContextService),
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -95,7 +97,8 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(null),
                 Mockito.eq(ClientAuth.NONE),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -112,7 +115,8 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://influxdb:8886"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test
@@ -139,7 +143,8 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(6000L));
+                Mockito.eq(6000L),
+                null);
     }
 
     @Test
@@ -168,7 +173,8 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(null),
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
-                Mockito.eq(0L));
+                Mockito.eq(0L),
+                null);
     }
 
     @Test

--- a/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings_2.java
+++ b/nifi-influx-database-services/src/test/java/org/influxdata/nifi/services/TestStandardInfluxDatabaseServiceSettings_2.java
@@ -56,7 +56,7 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -98,7 +98,7 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(ClientAuth.NONE),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://influxdb:8886"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(6000L),
-                null);
+                Mockito.any());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class TestStandardInfluxDatabaseServiceSettings_2 extends AbstractTestSta
                 Mockito.eq(InfluxDatabaseService_2.DEFAULT_CLIENT_AUTH),
                 Mockito.eq("http://localhost:8086"),
                 Mockito.eq(0L),
-                null);
+                Mockito.any());
     }
 
     @Test

--- a/nifi-influx-database-utils/src/main/java/org/influxdata/nifi/util/InfluxDBUtils.java
+++ b/nifi-influx-database-utils/src/main/java/org/influxdata/nifi/util/InfluxDBUtils.java
@@ -28,6 +28,7 @@ import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -263,6 +264,7 @@ public final class InfluxDBUtils {
      * @param password          the password for the username which is used to authorize against the influxDB instance
      * @param connectionTimeout the default connect timeout
      * @param configurer        to configure OkHttpClient.Builder with SSL
+     * @param clientType        to customize the User-Agent HTTP header
      * @return InfluxDB client
      */
     @Nonnull
@@ -270,8 +272,31 @@ public final class InfluxDBUtils {
                                             String username,
                                             String password,
                                             long connectionTimeout,
-                                            Consumer<OkHttpClient.Builder> configurer) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(connectionTimeout, TimeUnit.SECONDS);
+                                            Consumer<OkHttpClient.Builder> configurer,
+                                            final String clientType) {
+
+        // get version of influxdb-java
+        Package mainPackage = InfluxDBFactory.class.getPackage();
+        String version = mainPackage != null ? mainPackage.getImplementationVersion() : null;
+
+        // create User-Agent header content
+        String userAgent = String.format("influxdb-client-%s/%s",
+                clientType != null ? clientType : "java",
+                version != null ? version : "unknown");
+
+        OkHttpClient.Builder builder = new OkHttpClient
+                .Builder()
+                .connectTimeout(connectionTimeout, TimeUnit.SECONDS)
+                // add interceptor with "User-Agent" header
+                .addInterceptor(chain -> {
+                    Request request = chain
+                            .request()
+                            .newBuilder()
+                            .header("User-Agent", userAgent)
+                            .build();
+
+                    return chain.proceed(request);
+                });
         if (configurer != null) {
             configurer.accept(builder);
         }
@@ -289,25 +314,30 @@ public final class InfluxDBUtils {
      * @param token             the token to use for the authorization
      * @param connectionTimeout the default connect timeout
      * @param configurer        to configure OkHttpClient.Builder with SSL
+     * @param clientType        to customize the User-Agent HTTP header
      * @return InfluxDB client
      */
     @Nonnull
     public static InfluxDBClient makeConnectionV2(String influxDbUrl,
                                                   String token,
                                                   long connectionTimeout,
-                                                  Consumer<OkHttpClient.Builder> configurer) {
+                                                  Consumer<OkHttpClient.Builder> configurer,
+                                                  final String clientType) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(connectionTimeout, TimeUnit.SECONDS);
         if (configurer != null) {
             configurer.accept(builder);
         }
 
-        InfluxDBClientOptions options = InfluxDBClientOptions
+        InfluxDBClientOptions.Builder options = InfluxDBClientOptions
                 .builder()
                 .url(influxDbUrl)
                 .authenticateToken(token.toCharArray())
-                .okHttpClient(builder)
-                .build();
+                .okHttpClient(builder);
 
-        return InfluxDBClientFactory.create(options);
+        if (StringUtils.isNoneBlank(clientType)) {
+            options.clientType(clientType);
+        }
+
+        return InfluxDBClientFactory.create(options.build());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -206,13 +206,13 @@
             <dependency>
                 <groupId>org.influxdb</groupId>
                 <artifactId>influxdb-java</artifactId>
-                <version>2.20</version>
+                <version>2.22</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-java</artifactId>
-                <version>2.2.0</version>
+                <version>6.2.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- skip until remove org.json from Java client -->
+        <enforcer.skip>true</enforcer.skip>
 
         <nifi.version>1.14.0</nifi.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- skip until remove org.json from Java client -->
-        <enforcer.skip>true</enforcer.skip>
 
         <nifi.version>1.14.0</nifi.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-java</artifactId>
-                <version>6.2.0</version>
+                <version>6.3.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-java</artifactId>
-                <version>6.3.0-SNAPSHOT</version>
+                <version>6.3.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Proposed Changes

Added possibility to customise the `User-Agent` HTTP header:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/455137/176758590-82b154fc-3509-4db0-85ef-4b08c7402ccd.png">

<img width="773" alt="image" src="https://user-images.githubusercontent.com/455137/176759605-f2a5ff04-c586-4d8f-b96d-301c425461a3.png">

<img width="766" alt="image" src="https://user-images.githubusercontent.com/455137/176759347-76755ff7-a048-45d0-9925-f5231584c9ce.png">

Updated dependencies:

- `influxdb-java` to `2.22`
- `influxdb-client-java` to `6.3.0`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)