### PR TITLE
fix: use correct version for NiFi jars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,13 +117,34 @@ jobs:
             chmod +x ./codecov
             ./codecov
 
+  check-dependencies:
+    machine:
+      image: *default-machine-executor
+    steps:
+      - checkout
+      - install-jdk:
+          jdk-version: *default-jdk-version
+      - restore_cache:
+          name: Restoring Maven Cache
+          keys:
+            - &cache-dependencies-key maven-dependencies_v1-{{ checksum "pom.xml" }}-{{ checksum "nifi-influx-database-nar/pom.xml" }}-{{ checksum "nifi-influx-database-serialization/pom.xml" }}-{{ checksum "nifi-influx-database-serialization-nar/pom.xml" }}-{{ checksum "nifi-influx-database-services/pom.xml" }}-{{ checksum "nifi-influx-database-services-api/pom.xml" }}-{{ checksum "nifi-influx-database-services-nar/pom.xml" }}-{{ checksum "nifi-influx-database-utils/pom.xml" }}
+            - maven-dependencies_v1-
+      - run:
+          name: "Check dependency rules"
+          command: mvn enforcer:enforce -Drules=banDuplicatePomDependencyVersions,dependencyConvergence
+      - save_cache:
+          name: Saving Maven Cache
+          key: *cache-dependencies-key
+          paths:
+            - ~/.m2
+
   end-to-end:
     machine:
       image: *default-machine-executor
     steps:
       - checkout
       - install-jdk:
-          jdk-version:  *default-jdk-version
+          jdk-version: *default-jdk-version
       - restore_cache:
           name: Restoring Maven Cache
           keys:
@@ -171,6 +192,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - check-dependencies
       - tests-java:
           name: jdk-8
       - tests-java:
@@ -178,6 +200,7 @@ workflows:
           jdk-version: "11"
       - end-to-end:
           requires:
+            - check-dependencies
             - jdk-8
             - jdk-11
       - deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.21.0 [unreleased]
 
+### Bug Fixes
+1. [#75](https://github.com/influxdata/nifi-influxdb-bundle/pull/75): Use correct version for NiFi jars
+
 ## v1.20.0 [2022-07-04]
 
 ### Features

--- a/nifi-influx-database-processors/pom.xml
+++ b/nifi-influx-database-processors/pom.xml
@@ -54,10 +54,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-processor-utils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
         </dependency>
         <dependency>

--- a/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabaseRecordErrorHandling.java
+++ b/nifi-influx-database-processors/src/test/java/org/influxdata/nifi/processors/TestPutInfluxDatabaseRecordErrorHandling.java
@@ -33,6 +33,8 @@ import org.influxdata.nifi.util.InfluxDBUtils;
 import org.influxdb.InfluxDBException;
 import org.influxdb.InfluxDBIOException;
 import org.influxdb.dto.Point;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -285,7 +287,11 @@ public class TestPutInfluxDatabaseRecordErrorHandling extends AbstractTestPutInf
         // First is formatted message, Second Stack Trace
         Assert.assertEquals(1, errors.size());
 
-        Assert.assertTrue(errors.get(0).getMsg().contains(INFLUX_DB_ERROR_MESSAGE_LOG));
+        Assertions
+                .assertThat(errors.get(0).getMsg())
+                .endsWith(String.format(
+                        "Failed procession flow file %s due to unable to parse: org.influxdb.InfluxDBException$UnableToParseException: unable to parse",
+                        errors.get(0).getArgs()[1]));
 		Assert.assertEquals("org.influxdb.InfluxDBException$UnableToParseException: unable to parse", errors.get(0).getArgs()[3]);
     }
 
@@ -299,7 +305,11 @@ public class TestPutInfluxDatabaseRecordErrorHandling extends AbstractTestPutInf
         // First is formatted message, Second Stack Trace
         Assert.assertEquals(1, errors.size());
 
-        Assert.assertTrue(errors.get(0).getMsg().contains(INFLUX_DB_ERROR_MESSAGE_LOG));
+        Assertions
+                .assertThat(errors.get(0).getMsg())
+                .endsWith(String.format(
+                        "Failed procession flow file %s due to authorization failed: org.influxdb.InfluxDBException$AuthorizationFailedException: authorization failed",
+                        errors.get(0).getArgs()[1]));
         Assert.assertEquals("org.influxdb.InfluxDBException$AuthorizationFailedException: authorization failed", errors.get(0).getArgs()[3]);
     }
 

--- a/nifi-influx-database-services-api/pom.xml
+++ b/nifi-influx-database-services-api/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
-            <version>${nifi.version}</version>
         </dependency>
 
         <dependency>
@@ -66,7 +65,6 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
-            <version>${nifi.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/nifi-influx-database-services/pom.xml
+++ b/nifi-influx-database-services/pom.xml
@@ -50,8 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-processor-utils</artifactId>
-            <version>${nifi.version}</version>
+            <artifactId>nifi-utils</artifactId>
         </dependency>
 
         <dependency>
@@ -73,7 +72,6 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
-            <version>${nifi.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<!-- skip until remove org.json from Java client -->
         <enforcer.skip>true</enforcer.skip>
 
-        <nifi.version>1.14.0</nifi.version>
+        <nifi.version>1.16.3</nifi.version>
 
         <plugin.surefire.version>2.22.0</plugin.surefire.version>
         <plugin.jacoco.version>0.8.2</plugin.jacoco.version>
@@ -182,12 +182,6 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-schema-registry-service-api</artifactId>
-                <version>${nifi.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.nifi</groupId>
-                <artifactId>nifi-processor-utils</artifactId>
                 <version>${nifi.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Proposed Changes

1. Use correct version `1.16.3` for NiFi jars.
2. Add CircleCI check for dependencies.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)