### PR TITLE
chore(deps): update commons-lang3 and fix parsing boolean in LineProtocolParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Build:
     - influxdb-java to 2.23
     - commons-io to 2.11
+    - commons-lang3 to 3.12.0
     - gson to 2.9.0
 
 #### Test:

--- a/nifi-influx-database-serialization/src/main/java/org/influxdata/nifi/serialization/InfluxLineProtocolParser.java
+++ b/nifi-influx-database-serialization/src/main/java/org/influxdata/nifi/serialization/InfluxLineProtocolParser.java
@@ -17,6 +17,7 @@
 package org.influxdata.nifi.serialization;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,11 @@ import org.slf4j.LoggerFactory;
 public final class InfluxLineProtocolParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(InfluxLineProtocolParser.class);
+
+    /**
+     * <a href="https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/#boolean">Boolean accepted values</a>
+     */
+    private static final List<String> BOOLEAN_ACCEPTED = Arrays.asList("t", "true", "f", "false");
 
     // Internal
     private String lineProtocol;
@@ -394,9 +400,13 @@ public final class InfluxLineProtocolParser {
                     return Long.parseLong(value.substring(0, value.length() - 1));
                 }
 
-                Boolean bool = BooleanUtils.toBooleanObject(value);
-                if (bool != null) {
-                    return bool;
+                // We don't want parse the '0', '1' ... as a boolean. Accepted values:
+                // https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/#boolean
+                if (BOOLEAN_ACCEPTED.contains(value.toLowerCase())) {
+                    Boolean bool = BooleanUtils.toBooleanObject(value);
+                    if (bool != null) {
+                        return bool;
+                    }
                 }
 
                 //

--- a/nifi-influx-database-serialization/src/test/java/org/influxdata/nifi/serialization/TestInfluxLineProtocolParser.java
+++ b/nifi-influx-database-serialization/src/test/java/org/influxdata/nifi/serialization/TestInfluxLineProtocolParser.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The tests comes from https://github.com/influxdata/influxdb/blob/1.6/models/points_test.go.
+ * The tests comes from <a href="https://github.com/influxdata/influxdb/blob/1.6/models/points_test.go">points_test.go</a>.
  */
 public class TestInfluxLineProtocolParser {
 
@@ -1034,6 +1034,17 @@ public class TestInfluxLineProtocolParser {
 		Assert.assertNotNull(parser.getTags());
 		Assert.assertTrue(parser.getTags().isEmpty());
 	}
+
+    @Test
+    public void onlyValidBooleans() {
+
+        ExpectedResult.success()
+                .measurement("b")
+                .field("float1", 1F)
+                .field("float2", 0F)
+                .field("float3", 1.0F)
+                .validate("b float1=1,float2=0,float3=1.0");
+    }
 
     private static final class ExpectedResult {
 

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.0</version>
             </dependency>
             
         </dependencies>


### PR DESCRIPTION
## Proposed Changes

1. Updated `commons-lang3` to `3.12.0`
1. Fixed parsing `boolean` by LineProtocolParser

This is fixed PR for https://github.com/influxdata/nifi-influxdb-bundle/pull/82

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)