### PR TITLE
chore(ci): migrate Scheduled workflow to Scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ jobs:
 workflows:
   version: 2
   build:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - check-dependencies
       - tests-java:
@@ -211,12 +214,8 @@ workflows:
               only: master
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,6 @@ workflows:
 
   nightly:
     when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-java


### PR DESCRIPTION
## Proposed Changes

The **Scheduled Workflows** uses client for nightly builds but the scheduled workflows will be phased out by the end of 2022. The CircleCI's configuration has to be migrate to **Scheduled pipelines**.

- https://circleci.com/docs/workflows/#scheduling-a-workflow
- https://circleci.com/docs/scheduled-pipelines/#migrate-scheduled-workflows

Configured trigger:

![image](https://user-images.githubusercontent.com/455137/194825064-e126d0ab-6e44-47c2-829e-964069ff7052.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)