### PR TITLE
fix: copy Attributes on Splitting Result Sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.27.0 [unreleased]
 
+### Bug Fixes
+1. [#147](https://github.com/influxdata/nifi-influxdb-bundle/pull/147): Copy Attributes on Splitting Result Sets
+
 ## v1.26.0 [2023-12-05]
 
 ### Others

--- a/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractGetInfluxDatabase_2.java
+++ b/nifi-influx-database-processors/src/main/java/org/influxdata/nifi/processors/internal/AbstractGetInfluxDatabase_2.java
@@ -288,9 +288,14 @@ public abstract class AbstractGetInfluxDatabase_2 extends AbstractInfluxDatabase
             if (recordsPerFlowFile == -1 || createdFlowFile) {
                 this.flowFile = flowFile;
             } else {
-                this.flowFile = session.create();
+                FlowFile newflowFile = session.create();
+                if (!createdFlowFile) {
+                    newflowFile = session.putAllAttributes(newflowFile, flowFile.getAttributes());
+                }
+                this.flowFile = newflowFile;
                 this.flowFiles.add(this.flowFile);
             }
+
             this.org = org;
             this.recordsPerFlowFile = recordsPerFlowFile;
             this.query = query;
@@ -375,7 +380,9 @@ public abstract class AbstractGetInfluxDatabase_2 extends AbstractInfluxDatabase
             recordIndex++;
             if (recordsPerFlowFile != -1 && recordIndex > recordsPerFlowFile) {
                 closeRecordWriter();
-                flowFile = session.create();
+                FlowFile newflowFile = session.create();
+                newflowFile = session.putAllAttributes(newflowFile, flowFile.getAttributes());
+                flowFile = newflowFile;
                 flowFiles.add(flowFile);
                 recordIndex = 1;
             }


### PR DESCRIPTION
Closes #144 

## Proposed Changes

_Briefly describe your proposed changes:_
Just copied the attributes from the incoming flowFile and also hand them over, if there are subsequent one created.

## Checklist

- [x] Rebased/mergeable
- [x] Tests pass