### PR TITLE
fix: InfluxDB client read/write timeout settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.29.0 [unreleased]
 
+### Bug Fixes
+1. [#163](https://github.com/influxdata/nifi-influxdb-bundle/pull/163): Max connection timeout also used as read/write timeout.
+
 ## v1.28.0 [2024-03-01]
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Allows sharing connection configuration to InfluxDB 1.x  among more NiFi process
 | SSL Context Service | The SSL Context Service used to provide client certificate information for TLS/SSL connections |
 | Client Auth | The client authentication policy to use for the SSL Context. Only used if an SSL Context Service is provided. |
 | **InfluxDB connection URL** | InfluxDB URL to connect to. Eg: http://influxdb:8086 |
-| **InfluxDB Max Connection Time Out** | The maximum time for establishing connection to the InfluxDB |
+| **InfluxDB Max Connection Time Out** | The maximum time for establishing connection and reading/writing to the InfluxDB |
 | Username | Username which is used to authorize against the InfluxDB |
 | Password | Password for the username which is used to authorize against the InfluxDB. If the authorization fail the FlowFile will be penalized and routed to 'retry' relationship. |
 
@@ -284,7 +284,7 @@ Allows sharing connection configuration to InfluxDB 2.0 among more NiFi processo
 | SSL Context Service | The SSL Context Service used to provide client certificate information for TLS/SSL connections |
 | Client Auth | The client authentication policy to use for the SSL Context. Only used if an SSL Context Service is provided. |
 | **InfluxDB connection URL** | InfluxDB URL to connect to. Eg: http://influxdb:8086 |
-| **InfluxDB Max Connection Time Out** | The maximum time for establishing connection to the InfluxDB |
+| **InfluxDB Max Connection Time Out** | The maximum time for establishing connection and reading/writing to the InfluxDB |
 | **InfluxDB Access Token** | Access Token used for authenticating/authorizing the InfluxDB request sent by NiFi. |
 
 ### PutInfluxDatabase
@@ -297,7 +297,7 @@ Processor to write the content of a FlowFile in 'line protocol'. Please check de
 | --- | --- |
 | **Database Name** | InfluxDB database to connect to |
 | **InfluxDB connection URL** | InfluxDB URL to connect to. Eg: http://influxdb:8086 |
-| **InfluxDB Max Connection Time Out** | The maximum time for establishing connection to the InfluxDB |
+| **InfluxDB Max Connection Time Out** | The maximum time for establishing connection and reading/writing to the InfluxDB |
 | Username | Username for accessing InfluxDB |
 | Password | Password for user |
 | **Character Set** | Specifies the character set of the document data |

--- a/nifi-influx-database-utils/src/main/java/org/influxdata/nifi/util/InfluxDBUtils.java
+++ b/nifi-influx-database-utils/src/main/java/org/influxdata/nifi/util/InfluxDBUtils.java
@@ -287,6 +287,8 @@ public final class InfluxDBUtils {
         OkHttpClient.Builder builder = new OkHttpClient
                 .Builder()
                 .connectTimeout(connectionTimeout, TimeUnit.SECONDS)
+                .readTimeout(connectionTimeout, TimeUnit.SECONDS)
+                .writeTimeout(connectionTimeout, TimeUnit.SECONDS)
                 // add interceptor with "User-Agent" header
                 .addInterceptor(chain -> {
                     Request request = chain
@@ -323,7 +325,11 @@ public final class InfluxDBUtils {
                                                   long connectionTimeout,
                                                   Consumer<OkHttpClient.Builder> configurer,
                                                   final String clientType) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(connectionTimeout, TimeUnit.SECONDS);
+        OkHttpClient.Builder builder = new OkHttpClient
+                .Builder()
+                .connectTimeout(connectionTimeout, TimeUnit.SECONDS)
+                .readTimeout(connectionTimeout, TimeUnit.SECONDS)
+                .writeTimeout(connectionTimeout, TimeUnit.SECONDS);
         if (configurer != null) {
             configurer.accept(builder);
         }

--- a/nifi-influx-database-utils/src/test/java/org/influxdata/nifi/util/ITTestTimeout.java
+++ b/nifi-influx-database-utils/src/test/java/org/influxdata/nifi/util/ITTestTimeout.java
@@ -16,7 +16,11 @@
  */
 package org.influxdata.nifi.util;
 
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.query.FluxTable;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class ITTestTimeout {
     static final String INFLUX_DB_2_URL = "http://localhost:9999";
@@ -25,8 +29,8 @@ public class ITTestTimeout {
 
     @Test
     public void testReadTimeout() {
-        var influxDBClient = InfluxDBUtils.makeConnectionV2(INFLUX_DB_2_URL, INFLUX_DB_2_TOKEN, 60, null, null);
-        var unused = influxDBClient.getQueryApi().query("import \"array\"\n" +
+        InfluxDBClient influxDBClient = InfluxDBUtils.makeConnectionV2(INFLUX_DB_2_URL, INFLUX_DB_2_TOKEN, 60, null, null);
+        List<FluxTable> unused = influxDBClient.getQueryApi().query("import \"array\"\n" +
                 "import \"experimental/json\"\n" +
                 "import \"http/requests\"\n" +
                 "response = requests.get(url: \"http://httpbin:8080/delay/20\")\n" +

--- a/nifi-influx-database-utils/src/test/java/org/influxdata/nifi/util/ITTestTimeout.java
+++ b/nifi-influx-database-utils/src/test/java/org/influxdata/nifi/util/ITTestTimeout.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.influxdata.nifi.util;
+
+import org.junit.jupiter.api.Test;
+
+public class ITTestTimeout {
+    static final String INFLUX_DB_2_URL = "http://localhost:9999";
+    static final String INFLUX_DB_2_ORG = "my-org";
+    static final String INFLUX_DB_2_TOKEN = "my-token";
+
+    @Test
+    public void testReadTimeout() {
+        var influxDBClient = InfluxDBUtils.makeConnectionV2(INFLUX_DB_2_URL, INFLUX_DB_2_TOKEN, 60, null, null);
+        var unused = influxDBClient.getQueryApi().query("import \"array\"\n" +
+                "import \"experimental/json\"\n" +
+                "import \"http/requests\"\n" +
+                "response = requests.get(url: \"http://httpbin:8080/delay/20\")\n" +
+                "data = json.parse(data: response.body)\n" +
+                "array.from(rows: [{_field: \"origin\", _value: data.origin, _time: now()}])", INFLUX_DB_2_ORG);
+    }
+}


### PR DESCRIPTION
Closes #158 

## Proposed Changes

Uses max connection timeout also as read/write timeout in InfluxDB client.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)